### PR TITLE
Publish service image to dockerhub when building from master branch

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -1,5 +1,9 @@
-name: Verify
-on: [push]
+name: branch
+on:
+  push:
+    branches:
+      - "*"
+      - "!master"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,8 +2,6 @@ name: master
 on:
   push:
     branches:
-      # todo: remove before merging
-      - "*"
       - master
 jobs:
   build:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: 15
       - name: build
         run: >
-          mvn -B verify jib:build
+          mvn -B compile jib:build
           -Djib.to.image=docker.io/dimasmith/subscriptions-service
           -Djib.to.auth.username=${{ secrets.DOCKER_USERNAME }}
           -Djib.to.auth.password=${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,7 +1,23 @@
-name: Publish Docker Image
-on: [push]
+name: master
+on:
+  push:
+    branches:
+      # todo: remove before merging
+      - "*"
+      - master
 jobs:
   build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up java 15
+        uses: actions/setup-java@v1
+        with:
+          java-version: 15
+      - name: build
+        run: mvn -B verify --file pom.xml
+  publish:
+    needs: build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,4 +1,4 @@
-name: Verify
+name: Publish Docker Image
 on: [push]
 jobs:
   build:
@@ -11,7 +11,7 @@ jobs:
           java-version: 15
       - name: build
         run: >
-          mvn -B compile jib:build
+          mvn -B verify jib:build
           -Djib.to.image=docker.io/dimasmith/subscriptions-service
           -Djib.to.auth.username=${{ secrets.DOCKER_USERNAME }}
           -Djib.to.auth.password=${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish-docker-image.yml
+++ b/.github/workflows/publish-docker-image.yml
@@ -1,0 +1,18 @@
+name: Verify
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: set up java 15
+        uses: actions/setup-java@v1
+        with:
+          java-version: 15
+      - name: build
+        run: >
+          mvn -B compile jib:build
+          -Djib.to.image=docker.io/dimasmith/subscriptions-service
+          -Djib.to.auth.username=${{ secrets.DOCKER_USERNAME }}
+          -Djib.to.auth.password=${{ secrets.DOCKER_PASSWORD }}
+          --file pom.xml


### PR DESCRIPTION
Two workflows now working for the project:
* `branch` workflow runs tests on any push to any branch except of the master branch;
* `master` workflow runs all the tests and publishes docker image on success